### PR TITLE
fix: use app instead of core

### DIFF
--- a/src/admin/index.html
+++ b/src/admin/index.html
@@ -7,7 +7,7 @@
   </head>
   <body>
     <!-- Include the script that builds the page and powers Netlify CMS -->
-    <script src="https://unpkg.com/@staticcms/core@%5E1.0.0/dist/static-cms-app.js"></script>
+    <script src="https://unpkg.com/@staticcms/app@%5E1.0.0/dist/static-cms-app.js"></script>
 
     <!-- Netlify Identity Widget -->
     <script


### PR DESCRIPTION
The unpkg include was still calling the `core` package.